### PR TITLE
Implement UI components and backend essentials

### DIFF
--- a/apps/web/CampaignWizard.tsx
+++ b/apps/web/CampaignWizard.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+
+export interface CampaignWizardProps {
+  children?: React.ReactNode;
+  step?: number;
+}
+
+const steps = ["Goal & Budget", "Audience", "Creative"];
+
+export const CampaignWizard: React.FC<CampaignWizardProps> = ({ children, step = 0 }) => {
+  return (
+    <div className="rounded-magic bg-surface shadow-md p-6">
+      <div className="flex space-x-2 mb-4">
+        {steps.map((label, index) => (
+          <div
+            key={label}
+            className={`px-3 py-1 rounded-full text-sm ${index === step ? 'bg-primary-500 text-white' : 'bg-primary-50 text-primary-500'}`}
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+};
+
+export default CampaignWizard;

--- a/packages/server/migrations/20230912120000_create_tenant_tables.ts
+++ b/packages/server/migrations/20230912120000_create_tenant_tables.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex, tenantId: string): Promise<void> {
+  const schema = `tenant_${tenantId}`;
+
+  await knex.raw(`create schema if not exists ${schema}`);
+
+  await knex.schema.withSchema(schema).createTable('lead', (table) => {
+    table.uuid('id').primary();
+    table.string('phone');
+    table.text('source');
+    table.text('status');
+    table.jsonb('metadata');
+    table.uuid('assigned_to');
+    table.specificType('tags', 'text[]');
+    table.timestamp('created_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+
+  await knex.schema.withSchema(schema).createTable('facebook_assets', (table) => {
+    table.bigInteger('page_id').primary();
+    table.bigInteger('ad_account_id');
+    table.bigInteger('pixel_id');
+    table.text('access_token');
+    table.timestamp('connected_at', { useTz: true }).defaultTo(knex.fn.now());
+  });
+
+  await knex.raw(`alter table ${schema}.lead enable row level security`);
+  await knex.raw(`alter table ${schema}.facebook_assets enable row level security`);
+  await knex.raw(`create policy tenant_access on ${schema}.lead using (true)`);
+  await knex.raw(`create policy tenant_access on ${schema}.facebook_assets using (true)`);
+  await knex.raw(`create role if not exists tenant_rw`);
+  await knex.raw(`create role if not exists tenant_ro`);
+}
+
+export async function down(knex: Knex, tenantId: string): Promise<void> {
+  const schema = `tenant_${tenantId}`;
+  await knex.schema.withSchema(schema).dropTableIfExists('facebook_assets');
+  await knex.schema.withSchema(schema).dropTableIfExists('lead');
+}

--- a/packages/server/plugins/tenantAuth.ts
+++ b/packages/server/plugins/tenantAuth.ts
@@ -1,0 +1,35 @@
+import { FastifyPluginAsync } from 'fastify';
+import fp from 'fastify-plugin';
+
+export interface TenantAuthOptions {
+  pg: { query: (q: string, params?: any[]) => Promise<any> };
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    tenantId?: string;
+  }
+}
+
+const tenantAuthPlugin: FastifyPluginAsync<TenantAuthOptions> = async (
+  fastify,
+  opts
+) => {
+  fastify.decorateRequest('tenantId', null);
+
+  fastify.addHook('preHandler', async (request, reply) => {
+    const auth = request.headers.authorization;
+    if (!auth || !auth.startsWith('Bearer ')) {
+      reply.code(401).send({ error: 'Unauthorized' });
+      return;
+    }
+    const token = auth.substring('Bearer '.length);
+    const payload = await fastify.jwt.verify<{ tenant_id: string }>(token);
+    request.tenantId = payload.tenant_id;
+    await opts.pg.query(
+      'set search_path to tenant_' + payload.tenant_id + ',public'
+    );
+  });
+};
+
+export default fp(tenantAuthPlugin);

--- a/packages/ui/src/TopBar.tsx
+++ b/packages/ui/src/TopBar.tsx
@@ -1,0 +1,39 @@
+import * as React from "react";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+
+export interface TopBarProps {
+  tenantLogo?: string;
+  avatar?: string;
+}
+
+export const TopBar: React.FC<TopBarProps> = ({ tenantLogo, avatar }) => {
+  return (
+    <div className="flex items-center justify-between bg-surface p-4 shadow-md">
+      <div className="flex items-center">
+        <img
+          src={tenantLogo || "/logo.png"}
+          alt="tenant logo"
+          className="h-8"
+        />
+      </div>
+      <div className="text-primary-500 font-bold">QuickLaunch-Ads</div>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button className="focus:outline-none">
+            <img
+              src={avatar || "/avatar.png"}
+              alt="avatar"
+              className="h-8 w-8 rounded-full"
+            />
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content className="rounded-md bg-white shadow-md">
+          <DropdownMenu.Item className="px-3 py-2">Profile</DropdownMenu.Item>
+          <DropdownMenu.Item className="px-3 py-2">Sign out</DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
+  );
+};
+
+export default TopBar;

--- a/packages/ui/tailwind.config.js
+++ b/packages/ui/tailwind.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  presets: [require("@shadcn/ui/preset")],
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#EAF2FF',
+          300: '#4F94FF',
+          500: '#1777FF',
+        },
+        accent: '#31E1FF',
+        surface: '#FFFFFF',
+      },
+      borderRadius: {
+        magic: '1.25rem',
+      },
+      fontFamily: {
+        inter: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- set up Tailwind configuration with shadcn preset and custom tokens
- create a `TopBar` component with dropdown menu
- implement `CampaignWizard` skeleton component
- add Fastify `tenantAuth` plugin for JWT tenant switching
- add Knex migration for per‑tenant tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6874d56ea7908326a6d8cc81aed0772a